### PR TITLE
vmware optimization

### DIFF
--- a/machines/bob/configuration.nix
+++ b/machines/bob/configuration.nix
@@ -82,8 +82,8 @@
         version = 2;
         device = "nodev";
         efiSupport = true;
+        efiInstallAsRemovable = true;
       };
-      efi.canTouchEfiVariables = true;
     };
     cleanTmpDir = true;
   };

--- a/machines/bob/hardware-configuration.nix
+++ b/machines/bob/hardware-configuration.nix
@@ -13,14 +13,17 @@
   boot.extraModulePackages = [ ];
 
   fileSystems."/" = {
-    device = "/dev/disk/by-uuid/92f9e2c7-9d6c-4cb1-890b-ea638de88be1";
+    device = "/dev/disk/by-label/nixos";
+    autoResize = true;
     fsType = "ext4";
   };
 
   fileSystems."/boot" = {
-    device = "/dev/disk/by-uuid/0BB9-70CF";
+    device = "/dev/disk/by-label/ESP";
     fsType = "vfat";
   };
+
+  boot.growPartition = true;
 
   swapDevices = [ ];
 

--- a/machines/bob/hardware-configuration.nix
+++ b/machines/bob/hardware-configuration.nix
@@ -6,10 +6,9 @@
 {
   imports = [ ];
 
-  boot.initrd.availableKernelModules =
-    [ "ata_piix" "vmw_pvscsi" "sd_mod" "sr_mod" ];
+  boot.initrd.availableKernelModules = [ "ata_piix" "vmw_pvscsi" "sd_mod" ];
   boot.initrd.kernelModules = [ ];
-  boot.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-intel" ];
   boot.extraModulePackages = [ ];
 
   fileSystems."/" = {
@@ -26,5 +25,8 @@
   boot.growPartition = true;
 
   swapDevices = [ ];
+
+  hardware.cpu.intel.updateMicrocode =
+    lib.mkDefault config.hardware.enableRedistributableFirmware;
 
 }


### PR DESCRIPTION
- Partitionen werden via Label gemounted
- Die root Partition wächst nun automatisch
- Optimierungen für Intel CPU's werden geladen
- das kvm-intel Kernelmodul wird geladen
- der Bootloader wird portable installiert

-> Die Config wurde für eine VMWare VM optimiert
-> Die Config enthält keine VM spezifischen ID's mehr -> kann bspw. als Disk Image gebaut werden