### PR TITLE
bob: 32gb swapfile

### DIFF
--- a/machines/bob/hardware-configuration.nix
+++ b/machines/bob/hardware-configuration.nix
@@ -24,7 +24,10 @@
 
   boot.growPartition = true;
 
-  swapDevices = [ ];
+  swapDevices = [{
+    device = "/var/swapfile";
+    size = (1024 * 32);
+  }];
 
   hardware.cpu.intel.updateMicrocode =
     lib.mkDefault config.hardware.enableRedistributableFirmware;


### PR DESCRIPTION
Viele unserer Builds crashen im Moment, da 16GB RAM scheinbar nicht genug ist (webkitgtk ist da so ein nerviger Kandidat).
Ein Swapfile sollte das Problem ohne zusätzliche Hardware lösen.
