### PR TITLE
fix syntax error

### DIFF
--- a/modules/binary-cache/default.nix
+++ b/modules/binary-cache/default.nix
@@ -43,7 +43,7 @@ in {
     nix.settings.allowed-users = [ "nix-serve" "push-cache" ];
 
     nix.extraOptions = ''
-      secret-key-files = /run/keys/cache-priv-key;
+      secret-key-files = /run/keys/cache-priv-key
     '';
 
     # Write-key secret file


### PR DESCRIPTION
We can't use ;'s in nix.extraOptions, as those are interpreted as part of the file path.
By removing the symbol, builds should work again.