### PR TITLE
Add unzip dependency to tfenv derivation

### DIFF
--- a/packages/tfenv/default.nix
+++ b/packages/tfenv/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, lib, inputs, makeWrapper }:
+{ pkgs, stdenvNoCC, lib, inputs, makeWrapper }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "tfenv";
@@ -21,6 +21,7 @@ stdenvNoCC.mkDerivation rec {
   # expanding $HOME fails with --set-default.
   fixupPhase = ''
     wrapProgram $out/bin/tfenv \
+    --prefix PATH : "${lib.makeBinPath [ pkgs.unzip ]}" \
     --run 'export TFENV_CONFIG_DIR="''${TFENV_CONFIG_DIR:-$HOME/.local/tfenv}"' \
     --run 'mkdir -p $TFENV_CONFIG_DIR'
 


### PR DESCRIPTION
It's not used at build time, but is necessary at runtime in order to install terraform versions. The tfenv script itself expects `unzip` to be on the user's path.

This change makes it so that users installing the flake output `packages.${system}.tfenv` directly end up with a more complete installation of the package that pulls in the appropriate dependency on `unzip`.