### PR TITLE
bob: PVE specific changes 

### DIFF
--- a/machines/bob/configuration.nix
+++ b/machines/bob/configuration.nix
@@ -68,41 +68,14 @@
 
   users.users.root.openssh.authorizedKeys.keyFiles = [ mayniklas-keys ];
 
-  boot = {
-
-    # Enable arm emulation capabilities
-    binfmt.emulatedSystems = [ "aarch64-linux" ];
-
-    growPartition = true;
-
-    loader = {
-      grub = {
-        enable = true;
-        version = 2;
-        device = "nodev";
-        efiSupport = true;
-        efiInstallAsRemovable = true;
-      };
-    };
-    cleanTmpDir = true;
-  };
-
   networking = {
-
-    # DHCP
-    useDHCP = false;
-    interfaces.ens192.useDHCP = true;
-
     # Open ports in the firewall.
     firewall.allowedTCPPorts = [
       80
       443
       9100 # Node exporter. Host is behind external firewall
     ];
-
   };
-
-  virtualisation.vmware.guest.enable = true;
 
   # Workaround for problems with the dockerized CI
   systemd.enableUnifiedCgroupHierarchy = false;

--- a/machines/bob/hardware-configuration.nix
+++ b/machines/bob/hardware-configuration.nix
@@ -14,6 +14,12 @@
   boot.kernelModules = [ "kvm-intel" ];
   boot.extraModulePackages = [ ];
 
+  # enable fstrim to reduce disk image size
+  services.fstrim = {
+    enable = true;
+    interval = "weekly";
+  };
+
   fileSystems."/" = {
     device = "/dev/disk/by-label/nixos";
     autoResize = true;


### PR DESCRIPTION
Since we switched from VMWare -> Proxmox Virtual Environment, a few changes were within our configuration:
- we need some Kernel modules (so that we can use the virtio driver)
- replace VMWare guest services through qemu guest services
- new network interface name
- import (modulesPath + "/profiles/qemu-guest.nix")
- enable fstrim -> reduces vDisk size -> smaller backups

I also moved the device specific stuff into the hardware-configuration.nix file -> easier to read.