### PR TITLE
chore(navidrome): Use `RequiresMountsFor` for path dependency

### DIFF
--- a/clan-service-modules/navidrome.nix
+++ b/clan-service-modules/navidrome.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ ... }:
 {
   _class = "clan.service";
   manifest.name = "navidrome";

--- a/clan-service-modules/navidrome.nix
+++ b/clan-service-modules/navidrome.nix
@@ -61,7 +61,7 @@
               };
 
               # Ensure storagebox is mounted before navidrome starts
-              systemd.services.navidrome.unitConfig.RequiresMountsFor = [ config.pinpox.defaults.storagebox ];
+              systemd.services.navidrome.unitConfig.RequiresMountsFor = [ config.pinpox.defaults.storagebox.mountPoint ];
             };
           };
       };

--- a/clan-service-modules/navidrome.nix
+++ b/clan-service-modules/navidrome.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ config, ... }:
 {
   _class = "clan.service";
   manifest.name = "navidrome";
@@ -61,10 +61,7 @@
               };
 
               # Ensure storagebox is mounted before navidrome starts
-              systemd.services.navidrome = {
-                requires = [ "mnt-storagebox.mount" ];
-                after = [ "mnt-storagebox.mount" ];
-              };
+              systemd.services.navidrome.unitConfig.RequiresMountsFor = [ config.pinpox.defaults.storagebox ];
             };
           };
       };


### PR DESCRIPTION
Using `RequiresMountsFor` simplifies the config and allows reference to a global variable instead of hardcoding the corresponding systemd mount unit.

Ref: systemd.unit(5)

NOTE: Edit on GitHub directly; need eval test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Navidrome service startup to better wait for the storage mount, reducing startup failures.
  * Minor module configuration handling updated for clearer configuration usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pinpox/nixos/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->