### PR TITLE
ci: switch to Mic92/hestia@v1

### DIFF
--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v20
       - name: Setup hestia
-        uses: Mic92/hestia/action@v0.1.0-alpha.8
+        uses: Mic92/hestia@v1
         with:
           version: v0.1.0-alpha.8
       - name: Run garbage collection

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -30,8 +30,6 @@ jobs:
         uses: cachix/install-nix-action@v20
       - name: Setup hestia
         uses: Mic92/hestia@v1
-        with:
-          version: v0.1.0-alpha.8
       - name: Run garbage collection
         run: |
           "$HESTIA_BIN" gc ${{ inputs.dry-run && '--dry-run' || '' }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -16,8 +16,6 @@ jobs:
         uses: cachix/install-nix-action@v20
       - name: Setup hestia cache
         uses: Mic92/hestia@v1
-        with:
-          version: v0.1.0-alpha.8
       - name: Build manual
         run: |
           nix build '.#manual' --show-trace  -vv -L

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v20
       - name: Setup hestia cache
-        uses: Mic92/hestia/action@v0.1.0-alpha.8
+        uses: Mic92/hestia@v1
         with:
           version: v0.1.0-alpha.8
       - name: Build manual


### PR DESCRIPTION
Hestia [v1.0](https://github.com/Mic92/hestia/releases/tag/v1.0.2) moved `action.yml` to the repo root, so the path shortens from `Mic92/hestia/action@...` to `Mic92/hestia@v1`. Tracking the floating major tag keeps CI on the latest compatible 1.x release.